### PR TITLE
before_filter -> before_action for Rails 5.1

### DIFF
--- a/app/controllers/bones/wireframes_controller.rb
+++ b/app/controllers/bones/wireframes_controller.rb
@@ -1,7 +1,7 @@
 class Bones::WireframesController < ApplicationController
 
-  before_filter :capture_persisted_object
-  before_filter :initialize_persisted_object
+  before_action :capture_persisted_object
+  before_action :initialize_persisted_object
 
   def initialize_persisted_object
     object = Bones::PersistedModel.find(action_name)


### PR DESCRIPTION
Errors on Rails 5.1 for before_filter so before_filter must be beyond deprecated now